### PR TITLE
[#IC-348] Add trigger to fill fiscalCode on message_status from message collection

### DIFF
--- a/AddFiscalCodeToMessageStatus/__tests__/__snapshots__/handler.test.ts.snap
+++ b/AddFiscalCodeToMessageStatus/__tests__/__snapshots__/handler.test.ts.snap
@@ -1,0 +1,2200 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`patchAllVersion GIVEN an existing fiscalCode+id and a multiple patch response WHEN patch all version THEN return a successfull either 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        Object {
+          "id": "dummy-message-id-0000000000000000",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000001",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000002",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000003",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000004",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000005",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000006",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000007",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000008",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000009",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000010",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000011",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000012",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000013",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000014",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000015",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000016",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000017",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000018",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000019",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000020",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000021",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000022",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000023",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000024",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+      ],
+      Object {
+        "continueOnError": false,
+      },
+      undefined,
+    ],
+    Array [
+      Array [
+        Object {
+          "id": "dummy-message-id-0000000000000000",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000001",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000002",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000003",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000004",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000005",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000006",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000007",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000008",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000009",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000010",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000011",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000012",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000013",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000014",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000015",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000016",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000017",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000018",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000019",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000020",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000021",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000022",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000023",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000024",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+      ],
+      Object {
+        "continueOnError": false,
+      },
+      undefined,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": Promise {},
+    },
+    Object {
+      "type": "return",
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`patchAllVersion GIVEN an existing fiscalCode+id and a single patch response WHEN patch all version THEN return a successfull either 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        Object {
+          "id": "dummy-message-id-0000000000000000",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000001",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000002",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000003",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000004",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000005",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000006",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000007",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000008",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000009",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000010",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000011",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000012",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000013",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000014",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000015",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000016",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000017",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000018",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000019",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000020",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000021",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000022",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000023",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000024",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+      ],
+      Object {
+        "continueOnError": false,
+      },
+      undefined,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`patchAllVersion GIVEN an existing fiscalCode+id and am error patch response WHEN patch all version THEN return a failed either 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Array [
+        Object {
+          "id": "dummy-message-id-0000000000000000",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000001",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000002",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000003",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000004",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000005",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000006",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000007",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000008",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000009",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000010",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000011",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000012",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000013",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000014",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000015",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000016",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000017",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000018",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000019",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000020",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000021",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000022",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000023",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000024",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+      ],
+      Object {
+        "continueOnError": false,
+      },
+      undefined,
+    ],
+    Array [
+      Array [
+        Object {
+          "id": "dummy-message-id-0000000000000000",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000001",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000002",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000003",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000004",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000005",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000006",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000007",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000008",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000009",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000010",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000011",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000012",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000013",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000014",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000015",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000016",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000017",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000018",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000019",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000020",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000021",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000022",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000023",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000024",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+      ],
+      Object {
+        "continueOnError": false,
+      },
+      undefined,
+    ],
+    Array [
+      Array [
+        Object {
+          "id": "dummy-message-id-0000000000000000",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000001",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000002",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000003",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000004",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000005",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000006",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000007",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000008",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000009",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000010",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000011",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000012",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000013",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000014",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000015",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000016",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000017",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000018",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000019",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000020",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000021",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000022",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000023",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+        Object {
+          "id": "dummy-message-id-0000000000000024",
+          "operationType": "Patch",
+          "partitionKey": "dummy-message-id",
+          "resourceBody": Object {
+            "operations": Array [
+              Object {
+                "op": "add",
+                "path": "/fiscalCode",
+                "value": "FRLFRC74E04B157I",
+              },
+            ],
+          },
+        },
+      ],
+      Object {
+        "continueOnError": false,
+      },
+      undefined,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": Promise {},
+    },
+    Object {
+      "type": "return",
+      "value": Promise {},
+    },
+    Object {
+      "type": "return",
+      "value": Promise {},
+    },
+  ],
+}
+`;

--- a/AddFiscalCodeToMessageStatus/__tests__/handler.test.ts
+++ b/AddFiscalCodeToMessageStatus/__tests__/handler.test.ts
@@ -1,0 +1,152 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { FiscalCode } from "@pagopa/io-functions-commons/dist/generated/definitions/FiscalCode";
+import { Container, OperationResponse } from "@azure/cosmos";
+import { patchAllVersion } from "../handler";
+import * as E from "fp-ts/Either";
+import * as TE from "fp-ts/TaskEither";
+import { NewMessageWithoutContent } from "@pagopa/io-functions-commons/dist/src/models/message";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { TimeToLiveSeconds } from "@pagopa/io-functions-commons/dist/generated/definitions/TimeToLiveSeconds";
+import * as HANDLE from "../handler";
+
+const mockBulk = jest.fn();
+const mockContainer = ({
+  items: {
+    bulk: mockBulk
+  }
+} as unknown) as Container;
+
+const aFiscalCode = "FRLFRC74E04B157I" as FiscalCode;
+const aDummyId = "dummy-message-id" as NonEmptyString;
+
+describe("patchAllVersion", () => {
+  it("GIVEN an existing fiscalCode+id and a single patch response WHEN patch all version THEN return a successfull either", async () => {
+    mockBulk.mockImplementationOnce(() =>
+      Promise.resolve([{ statusCode: 200 }] as OperationResponse[])
+    );
+    const result = await patchAllVersion(mockContainer)({
+      fiscalCode: aFiscalCode,
+      id: aDummyId
+    })();
+    expect(E.isRight(result)).toBeTruthy();
+    expect(mockBulk).toMatchSnapshot();
+  });
+
+  it("GIVEN an existing fiscalCode+id and a multiple patch response WHEN patch all version THEN return a successfull either", async () => {
+    mockBulk.mockImplementationOnce(() =>
+      Promise.resolve([
+        { statusCode: 200 },
+        { statusCode: 404 },
+        { statusCode: 424 }
+      ] as OperationResponse[])
+    );
+    const result = await patchAllVersion(mockContainer)({
+      fiscalCode: aFiscalCode,
+      id: aDummyId
+    })();
+    expect(E.isRight(result)).toBeTruthy();
+    expect(mockBulk).toMatchSnapshot();
+  });
+
+  it("GIVEN an existing fiscalCode+id and am error patch response WHEN patch all version THEN return a failed either", async () => {
+    mockBulk.mockImplementationOnce(() =>
+      Promise.resolve([
+        { statusCode: 200 },
+        { statusCode: 200 },
+        { statusCode: 500 }
+      ] as OperationResponse[])
+    );
+    const result = await patchAllVersion(mockContainer)({
+      fiscalCode: aFiscalCode,
+      id: aDummyId
+    })();
+    expect(E.isLeft(result)).toBeTruthy();
+    if (E.isLeft(result)) {
+      expect(result.left).toEqual({
+        error: {
+          message: "Error patching document [200,200,500]",
+          name: "Patching Error"
+        },
+        kind: "COSMOS_ERROR_RESPONSE"
+      });
+    }
+    expect(mockBulk).toMatchSnapshot();
+  });
+});
+
+const cosmosMetadata = {
+  _etag: "_etag",
+  _rid: "_rid",
+  _self: "_self",
+  _ts: 1
+};
+const aSerializedNewMessageWithoutContent = {
+  createdAt: new Date().toISOString(),
+  fiscalCode: aFiscalCode,
+  id: "A_MESSAGE_ID" as NonEmptyString,
+  indexedId: "A_MESSAGE_ID" as NonEmptyString,
+  senderServiceId: "agid" as ServiceId,
+  senderUserId: "u123" as NonEmptyString,
+  timeToLiveSeconds: 3600 as TimeToLiveSeconds
+};
+const aNewMessageWithoutContent: NewMessageWithoutContent = {
+  ...aSerializedNewMessageWithoutContent,
+  createdAt: new Date(),
+  kind: "INewMessageWithoutContent"
+};
+const aRetrievedMessageWithoutContent = {
+  ...cosmosMetadata,
+  ...aSerializedNewMessageWithoutContent,
+  createdAt: new Date()
+};
+
+describe("handle", () => {
+  it("GIVEN an existing message WHEN handle the change feed THEN return a 200", async () => {
+    jest
+      .spyOn(HANDLE, "patchAllVersion")
+      .mockReturnValueOnce(() =>
+        TE.right([
+          { statusCode: 200 },
+          { statusCode: 404 },
+          { statusCode: 424 }
+        ] as OperationResponse[])
+      );
+    const results = await HANDLE.handle(mockContainer, [
+      aRetrievedMessageWithoutContent
+    ]);
+    expect(results).toEqual([200]);
+  });
+
+  it("GIVEN an existing message WHEN handle the change feed THEN return a 200", async () => {
+    jest
+      .spyOn(HANDLE, "patchAllVersion")
+      .mockReturnValueOnce(() =>
+        TE.right([
+          { statusCode: 200 },
+          { statusCode: 404 },
+          { statusCode: 424 }
+        ] as OperationResponse[])
+      );
+    const results = await HANDLE.handle(mockContainer, [
+      aRetrievedMessageWithoutContent
+    ]);
+    expect(results).toEqual([200]);
+  });
+
+  it("GIVEN a not working cosmos WHEN handle the change feed THEN throw a CosmosError", async () => {
+    jest.spyOn(HANDLE, "patchAllVersion").mockReturnValueOnce(() =>
+      TE.left({
+        error: {
+          message: "Error patching document [500]",
+          name: "Patching Error"
+        },
+        kind: "COSMOS_ERROR_RESPONSE"
+      })
+    );
+    await expect(
+      HANDLE.handle(mockContainer, [aRetrievedMessageWithoutContent])
+    ).rejects.toEqual(
+      expect.objectContaining({ kind: "COSMOS_ERROR_RESPONSE" })
+    );
+  });
+});

--- a/AddFiscalCodeToMessageStatus/function.json
+++ b/AddFiscalCodeToMessageStatus/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "cosmosDBTrigger",
+      "name": "rawMessageStatus",
+      "direction": "in",
+      "connectionStringSetting": "COSMOS_API_CONNECTION_STRING",
+      "databaseName": "%COSMOSDB_NAME%",
+      "collectionName": "messages",
+      "leaseCollectionName": "operations-leases-services",
+      "leaseCollectionPrefix": "addFiscalCodeToMessageStatus",
+      "createLeaseCollectionIfNotExists": true,
+      "startFromBeginning": true
+
+    }
+  ],
+  "scriptFile": "../dist/AddFiscalCodeToMessageStatus/index.js"
+}

--- a/AddFiscalCodeToMessageStatus/handler.ts
+++ b/AddFiscalCodeToMessageStatus/handler.ts
@@ -61,7 +61,7 @@ export const patchAllVersion: (
         ]
       }
     })),
-    readonlyPatchOperations => readonlyPatchOperations.slice(), // copy the readonly array to a mutable one
+    RA.toArray, // copy the readonly array to a mutable one
     patchOperations =>
       TE.tryCatch(
         () =>

--- a/AddFiscalCodeToMessageStatus/handler.ts
+++ b/AddFiscalCodeToMessageStatus/handler.ts
@@ -1,0 +1,123 @@
+import {
+  BulkOperationType,
+  Container,
+  OperationResponse,
+  PatchOperationType,
+  RequestOptions
+} from "@azure/cosmos";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as TE from "fp-ts/TaskEither";
+import {
+  CosmosErrorResponse,
+  CosmosErrors,
+  toCosmosErrorResponse
+} from "@pagopa/io-functions-commons/dist/src/utils/cosmosdb_model";
+import { flow, pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as AR from "fp-ts/Array";
+import { FiscalCode } from "@pagopa/io-functions-commons/dist/generated/definitions/FiscalCode";
+import { RetrievedMessageWithoutContent } from "@pagopa/io-functions-commons/dist/src/models/message";
+import * as T from "fp-ts/lib/Task";
+
+const VERSION_PADDING_LENGTH = 16;
+const getVersionedIds = (
+  messageId: string,
+  versionStart: number = 0,
+  maxBulk: number = 25 // Cosmos SDK limit = 100
+): ReadonlyArray<NonEmptyString> =>
+  RA.makeBy(
+    maxBulk,
+    i =>
+      `${messageId}-${(
+        "0".repeat(VERSION_PADDING_LENGTH) + String(versionStart + i)
+      ).slice(-VERSION_PADDING_LENGTH)}` as NonEmptyString
+  );
+
+export const patchAllVersion: (
+  container: Container,
+  options?: RequestOptions
+) => (message: {
+  readonly fiscalCode: FiscalCode;
+  readonly id: NonEmptyString;
+}) => TE.TaskEither<CosmosErrors, ReadonlyArray<OperationResponse>> = (
+  container,
+  options
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+) => ({ fiscalCode, id }) =>
+  pipe(
+    getVersionedIds(id, 0),
+    RA.map(messageStatusId => ({
+      id: messageStatusId,
+      operationType: BulkOperationType.Patch,
+      partitionKey: id,
+      resourceBody: {
+        operations: [
+          {
+            op: PatchOperationType.add,
+            path: `/fiscalCode`,
+            value: fiscalCode
+          }
+        ]
+      }
+    })),
+    readonlyPatchOperations => readonlyPatchOperations.slice(), // copy the readonly array to a mutable one
+    patchOperations =>
+      TE.tryCatch(
+        () =>
+          container.items.bulk(
+            patchOperations,
+            { continueOnError: false },
+            options
+          ),
+        toCosmosErrorResponse
+      ),
+    TE.filterOrElse(
+      results =>
+        pipe(
+          results,
+          AR.reduce(
+            true as boolean,
+            (hasError, response) =>
+              hasError || ![200, 404, 424].includes(response.statusCode)
+          )
+        ),
+      results =>
+        CosmosErrorResponse({
+          message: `Error patching document [${results.reduce(
+            (p, c, i, _a) => `${p}${i > 0 ? "," : ""}${c.statusCode}`,
+            ""
+          )}]`,
+          name: `Patching Error`
+        })
+    )
+  );
+
+export const handle = (
+  container: Container,
+  rawMessages: ReadonlyArray<unknown>
+): Promise<ReadonlyArray<number>> =>
+  pipe(
+    rawMessages,
+    RA.map(
+      flow(
+        RetrievedMessageWithoutContent.decode,
+        TE.fromEither,
+        TE.chainW(patchAllVersion(container)),
+        TE.map(responses =>
+          pipe(
+            responses,
+            RA.reduce(404, (previous, result) =>
+              result.statusCode === 200 ? previous : result.statusCode
+            )
+          )
+        ),
+        TE.mapLeft(e => {
+          throw e;
+        }),
+        TE.toUnion
+      )
+    ),
+    RA.sequence(T.ApplicativePar)
+  )();
+
+export default handle;

--- a/AddFiscalCodeToMessageStatus/index.ts
+++ b/AddFiscalCodeToMessageStatus/index.ts
@@ -16,16 +16,6 @@ const messageStatusContainer = cosmosdbInstance.container(
   MESSAGE_STATUS_COLLECTION_NAME
 );
 
-// const config = getConfigOrThrow();
-// const errorStorage = new TableClient(
-//   `https://${config.ERROR_STORAGE_ACCOUNT}.table.core.windows.net`,
-//   config.ERROR_STORAGE_TABLE,
-//   new AzureNamedKeyCredential(
-//     config.ERROR_STORAGE_ACCOUNT,
-//     config.ERROR_STORAGE_KEY
-//   )
-// );
-
 const run = async (
   context: Context,
   rawMessageStatus: ReadonlyArray<unknown>

--- a/AddFiscalCodeToMessageStatus/index.ts
+++ b/AddFiscalCodeToMessageStatus/index.ts
@@ -1,0 +1,37 @@
+import * as winston from "winston";
+import { Context } from "@azure/functions";
+import { AzureContextTransport } from "@pagopa/io-functions-commons/dist/src/utils/logging";
+import { MESSAGE_STATUS_COLLECTION_NAME } from "@pagopa/io-functions-commons/dist/src/models/message_status";
+import { cosmosdbInstance } from "../utils/cosmosdb";
+import handle from "./handler";
+
+// eslint-disable-next-line functional/no-let
+let logger: Context["log"] | undefined;
+const contextTransport = new AzureContextTransport(() => logger, {
+  level: "debug"
+});
+winston.add(contextTransport);
+
+const messageStatusContainer = cosmosdbInstance.container(
+  MESSAGE_STATUS_COLLECTION_NAME
+);
+
+// const config = getConfigOrThrow();
+// const errorStorage = new TableClient(
+//   `https://${config.ERROR_STORAGE_ACCOUNT}.table.core.windows.net`,
+//   config.ERROR_STORAGE_TABLE,
+//   new AzureNamedKeyCredential(
+//     config.ERROR_STORAGE_ACCOUNT,
+//     config.ERROR_STORAGE_KEY
+//   )
+// );
+
+const run = async (
+  context: Context,
+  rawMessageStatus: ReadonlyArray<unknown>
+): Promise<ReadonlyArray<number>> => {
+  logger = context.log;
+  return handle(messageStatusContainer, rawMessageStatus);
+};
+
+export default run;

--- a/Info/__tests__/handler.test.ts
+++ b/Info/__tests__/handler.test.ts
@@ -1,4 +1,7 @@
-import { HealthCheck, HealthProblem } from "@pagopa/io-functions-commons/dist/src/utils/healthcheck";
+import {
+  HealthCheck,
+  HealthProblem
+} from "@pagopa/io-functions-commons/dist/src/utils/healthcheck";
 import * as TE from "fp-ts/lib/TaskEither";
 import { InfoHandler } from "../handler";
 
@@ -8,7 +11,7 @@ afterEach(() => {
 
 describe("InfoHandler", () => {
   it("should return an internal error if the application is not healthy", async () => {
-    const healthCheck: HealthCheck = TE.left([
+    const healthCheck: HealthCheck<"Config"> = TE.left([
       "failure 1" as HealthProblem<"Config">,
       "failure 2" as HealthProblem<"Config">
     ]);
@@ -20,8 +23,8 @@ describe("InfoHandler", () => {
   });
 
   it("should return a success if the application is healthy", async () => {
-    const healthCheck: HealthCheck = TE.of(true);
-    const handler = InfoHandler(_=> healthCheck);
+    const healthCheck: HealthCheck<"Config"> = TE.of(true);
+    const handler = InfoHandler(_ => healthCheck);
 
     const response = await handler();
 

--- a/Info/handler.ts
+++ b/Info/handler.ts
@@ -27,7 +27,7 @@ type InfoHandler = () => Promise<
 
 type HealthChecker = (
   config: unknown
-) => healthcheck.HealthCheck<healthcheck.ProblemSource, true>;
+) => healthcheck.HealthCheck<"Config" | "AzureCosmosDB", true>;
 
 export const InfoHandler = (
   checkApplicationHealth: HealthChecker

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@azure/cosmos": "^3.11.5",
+    "@azure/cosmos": "^3.15.1",
     "@azure/data-tables": "^13.0.0",
     "@chasdevs/avro-to-typescript": "^1.4.0",
     "@pagopa/express-azure-functions": "^2.0.0",
-    "@pagopa/io-functions-commons": "^21.8.0",
+    "@pagopa/io-functions-commons": "^23.2.0",
     "@pagopa/ts-commons": "^10.1.0",
     "avsc": "^5.7.3",
     "azure-storage": "^2.10.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,21 @@
     tslib "^2.2.0"
     uuid "^8.3.0"
 
+"@azure/core-rest-pipeline@^1.2.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-rest-pipeline/-/core-rest-pipeline-1.6.0.tgz#f833a0836779a40300a3633fa73ad8a63186ca73"
+  integrity sha512-9Euoat1TPR97Q1l5aylxhDyKbtp2hv15AoFeOwC5frQAFNJegtDDf6BUBr7OiAggzjGAYidxkyhL0T6Yu05XWQ==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-auth" "^1.3.0"
+    "@azure/core-tracing" "1.0.0-preview.13"
+    "@azure/logger" "^1.0.0"
+    form-data "^4.0.0"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    tslib "^2.2.0"
+    uuid "^8.3.0"
+
 "@azure/core-tracing@1.0.0-preview.13":
   version "1.0.0-preview.13"
   resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz#55883d40ae2042f6f1e12b17dd0c0d34c536d644"
@@ -73,17 +88,17 @@
     tslib "^2.2.0"
     xml2js "^0.4.19"
 
-"@azure/cosmos@^3.11.5":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@azure/cosmos/-/cosmos-3.13.1.tgz#644c4e56b00ff5151288877f9ba2d0c33d8e694a"
-  integrity sha512-bKSPH0UsdAtcTFOL7f9/A7kajd4SexzP2bkcOaR2ahIiO2xQk2jUAJwEB1TBtYC40vDAEtJ2tdidxfJaHVeyZw==
+"@azure/cosmos@^3.15.1":
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/@azure/cosmos/-/cosmos-3.15.1.tgz#5b206f061cdf0bb387cf92ac13e25c9190f929c4"
+  integrity sha512-Pjn9CcoipUSsm/r9ZqAeyrqIQnh0AOeIDwYs/3pcLumK9ezCVFrfeLoOfas4Dm2X8bwL+/9puKAM55LJEaQwWg==
   dependencies:
     "@azure/core-auth" "^1.3.0"
-    "@azure/core-rest-pipeline" "^1.1.0"
+    "@azure/core-rest-pipeline" "^1.2.0"
     debug "^4.1.1"
     fast-json-stable-stringify "^2.1.0"
     jsbi "^3.1.3"
-    node-abort-controller "^1.2.0"
+    node-abort-controller "^3.0.0"
     priorityqueuejs "^1.0.0"
     semaphore "^1.0.5"
     tslib "^2.2.0"
@@ -754,12 +769,12 @@
   resolved "https://registry.yarnpkg.com/@pagopa/express-azure-functions/-/express-azure-functions-2.0.0.tgz#eb52a0b997d931c1509372e2a9bea22a8ca85c17"
   integrity sha512-IFZqtk0e2sfkMZIxYqPORzxcKRkbIrVJesR6eMLNwzh1rA4bl2uh9ZHk1m55LNq4ZmaxREDu+1JcGlIaZQgKNQ==
 
-"@pagopa/io-functions-commons@^21.8.0":
-  version "21.8.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-21.8.0.tgz#d549cec2212834c1b688950e2fa0c398d13da8ab"
-  integrity sha512-K3j6zu/tX2GpmMT9PnoO3pLXcr8QdNiLQrYaohMJyCFiFuQs6hNFRSHKDjPgutoHKOVbal7HAJxTZvlGxgTw9w==
+"@pagopa/io-functions-commons@^23.2.0":
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-23.2.0.tgz#5075b9f3c938003011160d8198fd5b57c64dc408"
+  integrity sha512-iQnbwaHXNj9XHCt9S/9V+56qoWbbcIBLo9fTCb0L2sCv6UxDiPf87b5x/YLKzV84gSZlkfOv7Fd8nS2AHyzbnQ==
   dependencies:
-    "@azure/cosmos" "^3.11.5"
+    "@azure/cosmos" "^3.15.1"
     "@pagopa/ts-commons" "^10.0.1"
     applicationinsights "^1.8.10"
     azure-storage "^2.10.5"
@@ -3858,6 +3873,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -6765,10 +6789,10 @@ node-abi@^2.7.0:
   dependencies:
     semver "^5.4.1"
 
-node-abort-controller@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-1.2.1.tgz#1eddb57eb8fea734198b11b28857596dc6165708"
-  integrity sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ==
+node-abort-controller@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
+  integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
 
 node-cleanup@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The message_status do not contains the fiscalCode. This will not allow us to query a message from its status (query with messageId only cost 8 time more). This trigger will fill all the existing message_status with the fiscalCode.

#### List of Changes
<!--- Describe your changes in detail -->
Add trigger on message collection to fill message_status fiscalCode

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow to query a message from its message_status 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
system test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
