### PR TITLE
[#IOPID-1908 #IOPID-1920] Add change feed processor for profiles container

### DIFF
--- a/AnalyticsProfilesChangeFeedInboundProcessorAdapter/function.json
+++ b/AnalyticsProfilesChangeFeedInboundProcessorAdapter/function.json
@@ -3,7 +3,7 @@
     {
       "authLevel": "function",
       "type": "cosmosDBTrigger",
-      "name": "cosmosApiServicePreferencesTrigger",
+      "name": "cosmosApiProfilesTrigger",
       "direction": "in",
       "connection": "COSMOS_API_CONNECTION_STRING",
       "databaseName": "%COSMOSDB_NAME%",

--- a/AnalyticsProfilesChangeFeedInboundProcessorAdapter/function.json
+++ b/AnalyticsProfilesChangeFeedInboundProcessorAdapter/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "cosmosDBTrigger",
+      "name": "cosmosApiServicePreferencesTrigger",
+      "direction": "in",
+      "connection": "COSMOS_API_CONNECTION_STRING",
+      "databaseName": "%COSMOSDB_NAME%",
+      "containerName": "profiles",
+      "leaseContainerPrefix": "%PROFILES_LEASES_PREFIX%-",
+      "leaseContainerName": "pdnd-leases",
+      "createLeaseContainerIfNotExists": false,
+      "startFromBeginning": true
+
+    }
+  ],
+  "scriptFile": "../dist/AnalyticsProfilesChangeFeedInboundProcessorAdapter/index.js"
+}

--- a/AnalyticsProfilesChangeFeedInboundProcessorAdapter/index.ts
+++ b/AnalyticsProfilesChangeFeedInboundProcessorAdapter/index.ts
@@ -1,0 +1,94 @@
+import { QueueClient } from "@azure/storage-queue";
+import { Context } from "@azure/functions";
+
+import * as t from "io-ts";
+
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+
+import * as KA from "../outbound/adapter/kafka-outbound-publisher";
+import * as KP from "../utils/kafka/KafkaProducerCompact";
+import * as QA from "../outbound/adapter/queue-outbound-mapper-publisher";
+import * as TA from "../outbound/adapter/tracker-outbound-publisher";
+import * as PF from "../outbound/adapter/predicate-outbound-filterer";
+import * as PDVA from "../outbound/adapter/pdv-id-outbound-enricher";
+
+import { getAnalyticsProcessorForDocuments } from "../businesslogic/analytics-publish-documents";
+
+import { ValidableKafkaProducerConfig } from "../utils/kafka/KafkaTypes";
+import { getConfigOrThrow, withTopic } from "../utils/config";
+import { OutboundPublisher } from "../outbound/port/outbound-publisher";
+import { OutboundEnricher } from "../outbound/port/outbound-enricher";
+import { OutboundFilterer } from "../outbound/port/outbound-filterer";
+import { profilesAvroFormatter } from "../utils/formatter/profilesAvroFormatter";
+
+export type RetrievedProfileWithMaybePdvId = t.TypeOf<
+  typeof RetrievedProfileWithMaybePdvId
+>;
+const RetrievedProfileWithMaybePdvId = t.intersection([
+  RetrievedProfile,
+  t.partial({ userPDVId: NonEmptyString })
+]);
+
+const config = getConfigOrThrow();
+
+const profilesConfig = withTopic(
+  config.profilesKafkaTopicConfig.PROFILES_TOPIC_NAME,
+  config.profilesKafkaTopicConfig.PROFILES_TOPIC_CONNECTION_STRING
+)(config.targetKafka);
+
+const profilesTopic = {
+  ...profilesConfig,
+  messageFormatter: profilesAvroFormatter()
+};
+
+const profilesOnKafkaAdapter: OutboundPublisher<RetrievedProfileWithMaybePdvId> = KA.create(
+  KP.fromConfig(
+    profilesConfig as ValidableKafkaProducerConfig, // cast due to wrong association between Promise<void> and t.Function ('brokers' field)
+    profilesTopic
+  )
+);
+
+const profilesOnQueueAdapter: OutboundPublisher<RetrievedProfileWithMaybePdvId> = QA.create(
+  profile => {
+    // void storing userPDVId it in queue
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { userPDVId, ...rest } = profile;
+    return rest;
+  },
+  new QueueClient(
+    config.INTERNAL_STORAGE_CONNECTION_STRING,
+    config.SERVICE_PREFERENCES_FAILURE_QUEUE_NAME
+  )
+);
+
+const pdvIdEnricherAdapter: OutboundEnricher<RetrievedProfileWithMaybePdvId> = PDVA.create<
+  RetrievedProfileWithMaybePdvId
+>(config.ENRICH_PDVID_THROTTLING);
+
+const telemetryAdapter = TA.create(
+  TA.initTelemetryClient(config.APPINSIGHTS_INSTRUMENTATIONKEY)
+);
+
+const internalTestFiscalCodeSet = new Set(
+  config.INTERNAL_TEST_FISCAL_CODES as ReadonlyArray<FiscalCode>
+);
+const profilesFilterer: OutboundFilterer<RetrievedProfile> = PF.create(
+  retrievedProfile =>
+    !internalTestFiscalCodeSet.has(retrievedProfile.fiscalCode)
+);
+
+const run = (
+  _context: Context,
+  documents: ReadonlyArray<unknown>
+): Promise<void> =>
+  getAnalyticsProcessorForDocuments(
+    RetrievedProfile,
+    telemetryAdapter,
+    pdvIdEnricherAdapter,
+    profilesOnKafkaAdapter,
+    profilesOnQueueAdapter,
+    profilesFilterer
+  ).process(documents)();
+
+export default run;

--- a/AnalyticsProfilesChangeFeedInboundProcessorAdapter/index.ts
+++ b/AnalyticsProfilesChangeFeedInboundProcessorAdapter/index.ts
@@ -58,7 +58,7 @@ const profilesOnQueueAdapter: OutboundPublisher<RetrievedProfileWithMaybePdvId> 
   },
   new QueueClient(
     config.INTERNAL_STORAGE_CONNECTION_STRING,
-    config.SERVICE_PREFERENCES_FAILURE_QUEUE_NAME
+    config.PROFILES_FAILURE_QUEUE_NAME
   )
 );
 

--- a/businesslogic/__mocks__/processor.mock.ts
+++ b/businesslogic/__mocks__/processor.mock.ts
@@ -1,0 +1,64 @@
+import { QueueClient } from "@azure/storage-queue";
+import { TelemetryClient } from "applicationinsights";
+import { pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/ReadonlyArray";
+import { Producer, ProducerRecord } from "kafkajs";
+import * as KA from "../../outbound/adapter/kafka-outbound-publisher";
+import * as QAF from "../../outbound/adapter/queue-outbound-mapper-publisher";
+import * as TA from "../../outbound/adapter/tracker-outbound-publisher";
+import * as PDVA from "../../outbound/adapter/pdv-id-outbound-enricher";
+import { OutboundPublisher } from "../../outbound/port/outbound-publisher";
+import * as pdv from "../../utils/pdv";
+
+export const aTopic = "a-topic";
+export const anError = new Error("An error");
+
+// Mocks
+export const mockTrackException = jest.fn(_ => void 0);
+export const trackerMock = ({
+  trackException: mockTrackException
+} as unknown) as TelemetryClient;
+
+export const mockSendMessageViaQueue = jest.fn(() => Promise.resolve());
+export const mockQueueClient = ({
+  sendMessage: mockSendMessageViaQueue
+} as unknown) as QueueClient;
+
+export const aKafkaResponse = {
+  errorCode: 0,
+  partition: 1,
+  topicName: aTopic
+};
+export const mockSendMessageViaTopic = jest.fn(async (pr: ProducerRecord) =>
+  pipe(
+    pr.messages,
+    RA.map(() => aKafkaResponse)
+  )
+);
+export const producerMock = () => ({
+  producer: ({
+    connect: jest.fn(async () => void 0),
+    disconnect: jest.fn(async () => void 0),
+    send: mockSendMessageViaTopic
+  } as unknown) as Producer,
+  topic: { topic: aTopic }
+});
+
+export const mockGetPdvId = jest.spyOn(pdv, "getPdvId");
+
+export const trackerAdapter = TA.create(trackerMock);
+
+export const getPdvIdEnricherAdapter = <
+  T extends PDVA.MaybePdvDocumentsTypes
+>() => PDVA.create<T>(10);
+
+export const getMainAdapter = <T extends PDVA.MaybePdvDocumentsTypes>() =>
+  KA.create(producerMock) as OutboundPublisher<T>;
+
+export const getFallbackAdapterWithFilter = <
+  T extends PDVA.MaybePdvDocumentsTypes
+>() =>
+  QAF.create(docWithPDVId => {
+    const { userPDVId, ...rest } = docWithPDVId;
+    return rest;
+  }, mockQueueClient) as OutboundPublisher<T>;

--- a/businesslogic/__mocks__/processor.mock.ts
+++ b/businesslogic/__mocks__/processor.mock.ts
@@ -13,6 +13,13 @@ import * as pdv from "../../utils/pdv";
 export const aTopic = "a-topic";
 export const anError = new Error("An error");
 
+export const aCosmosMetadata = {
+  _etag: "_etag",
+  _rid: "_rid",
+  _self: "xyz",
+  _ts: 1
+};
+
 // Mocks
 export const mockTrackException = jest.fn(_ => void 0);
 export const trackerMock = ({

--- a/businesslogic/__mocks__/test-case.ts
+++ b/businesslogic/__mocks__/test-case.ts
@@ -1,0 +1,84 @@
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import { sha256 } from "../../utils/pdv";
+import {
+  aTopic,
+  mockGetPdvId,
+  mockSendMessageViaQueue,
+  mockSendMessageViaTopic,
+  mockTrackException
+} from "./processor.mock";
+import { pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/ReadonlyArray";
+
+export const getSuccessValidListExpects = <
+  T extends { fiscalCode: FiscalCode }
+>(
+  documents: Array<T>
+) => {
+  expect(mockGetPdvId).toHaveBeenCalledTimes(2);
+  expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
+  expect(mockSendMessageViaTopic).toHaveBeenCalledWith({
+    messages: documents.map(document => ({
+      value: JSON.stringify({
+        ...document,
+        // enriched values
+        userPDVId: sha256(document.fiscalCode)
+      })
+    })),
+    topic: aTopic
+  });
+  expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(0);
+  expect(mockTrackException).toHaveBeenCalledTimes(0);
+};
+
+export const getKafkaProducerFailureExpects = <
+  T extends { fiscalCode: FiscalCode }
+>(
+  documents: Array<T>
+) => {
+  expect(mockGetPdvId).toHaveBeenCalledTimes(2);
+  expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
+  expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(2);
+  pipe(
+    documents,
+    RA.mapWithIndex((i, document) =>
+      expect(mockSendMessageViaQueue).toHaveBeenNthCalledWith(
+        i + 1,
+        Buffer.from(
+          JSON.stringify({
+            ...document
+            // DO NOT store pdvId values
+            // userPDVId: sha256(document.fiscalCode)
+          })
+        ).toString("base64")
+      )
+    )
+  );
+  expect(mockTrackException).toHaveBeenCalledTimes(0);
+};
+
+export const getEnricherFailureExpecter = <
+  T extends { fiscalCode: FiscalCode }
+>(
+  documents: Array<T>
+) => {
+  expect(mockGetPdvId).toHaveBeenCalledTimes(2);
+  expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
+  expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(1);
+  pipe(
+    [documents[0]],
+    RA.mapWithIndex((i, document) =>
+      expect(mockSendMessageViaQueue).toHaveBeenNthCalledWith(
+        i + 1,
+        Buffer.from(
+          JSON.stringify({
+            ...document
+            // DO NOT store pdvId values
+            // userPDVId: sha256(document.fiscalCode)
+          })
+        ).toString("base64")
+      )
+    )
+  );
+  expect(mockTrackException).toHaveBeenCalledTimes(0);
+};

--- a/businesslogic/__tests__/analytics-profiles.test.ts
+++ b/businesslogic/__tests__/analytics-profiles.test.ts
@@ -1,10 +1,7 @@
 import { QueueClient } from "@azure/storage-queue";
 import { TelemetryClient } from "applicationinsights";
 import * as TE from "fp-ts/TaskEither";
-import {
-  INonNegativeIntegerTag,
-  NonNegativeInteger
-} from "@pagopa/ts-commons/lib/numbers";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { Producer, ProducerRecord } from "kafkajs";
 
@@ -69,7 +66,7 @@ const aRetrievedProfileList = [
   {
     ...aRetrievedProfile,
     id: `${aFiscalCode}-0000000000000003` as NonEmptyString,
-    settingsVersion: 3 as number & INonNegativeIntegerTag,
+    settingsVersion: 3 as NonNegativeInteger,
     _ts: 1637077231001
   }
 ];

--- a/businesslogic/__tests__/analytics-profiles.test.ts
+++ b/businesslogic/__tests__/analytics-profiles.test.ts
@@ -2,23 +2,19 @@ import * as TE from "fp-ts/TaskEither";
 import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
 import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
-import { pipe } from "fp-ts/lib/function";
-import * as RA from "fp-ts/ReadonlyArray";
-
 import { getAnalyticsProcessorForDocuments } from "../analytics-publish-documents";
 
 import { aFiscalCode } from "../../__mocks__/services.mock";
-import { sha256 } from "../../utils/pdv";
 import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
 import { ReminderStatusEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ReminderStatus";
 import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
 import { PushNotificationsContentTypeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PushNotificationsContentType";
 import {
+  aCosmosMetadata,
+  anError,
   mockGetPdvId,
-  mockSendMessageViaQueue,
   mockSendMessageViaTopic,
-  mockTrackException,
   trackerAdapter
 } from "../__mocks__/processor.mock";
 import {
@@ -26,18 +22,13 @@ import {
   getMainAdapter,
   getFallbackAdapterWithFilter
 } from "../__mocks__/processor.mock";
+import {
+  getEnricherFailureExpecter,
+  getKafkaProducerFailureExpects,
+  getSuccessValidListExpects
+} from "../__mocks__/test-case";
 
 // Data
-
-const aTopic = "a-topic";
-const anError = new Error("An error");
-
-const aCosmosMetadata = {
-  _etag: "_etag",
-  _rid: "_rid",
-  _self: "xyz",
-  _ts: 1
-};
 
 const aRetrievedProfile: RetrievedProfile = {
   ...aCosmosMetadata,
@@ -90,20 +81,7 @@ describe("publish", () => {
     // When
     await processorAdapter.process(documents)();
     // Then
-    expect(mockGetPdvId).toHaveBeenCalledTimes(2);
-    expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
-    expect(mockSendMessageViaTopic).toHaveBeenCalledWith({
-      messages: documents.map(document => ({
-        value: JSON.stringify({
-          ...document,
-          // enriched values
-          userPDVId: sha256(document.fiscalCode)
-        })
-      })),
-      topic: aTopic
-    });
-    expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(0);
-    expect(mockTrackException).toHaveBeenCalledTimes(0);
+    getSuccessValidListExpects(documents);
   });
 
   it("GIVEN a valid list of profile and a not working Kafka Producer Client, WHEN processing the list, THEN send it to the queue", async () => {
@@ -122,25 +100,7 @@ describe("publish", () => {
     // When
     await processorAdapter.process(documents)();
     // Then
-    expect(mockGetPdvId).toHaveBeenCalledTimes(2);
-    expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
-    expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(2);
-    pipe(
-      documents,
-      RA.mapWithIndex((i, document) =>
-        expect(mockSendMessageViaQueue).toHaveBeenNthCalledWith(
-          i + 1,
-          Buffer.from(
-            JSON.stringify({
-              ...document
-              // DO NOT store pdvId values
-              // userPDVId: sha256(document.fiscalCode)
-            })
-          ).toString("base64")
-        )
-      )
-    );
-    expect(mockTrackException).toHaveBeenCalledTimes(0);
+    getKafkaProducerFailureExpects(documents);
   });
 
   it("GIVEN a valid list of profiles and a transient error on content enricher, WHEN processing the list, THEN send it to the queue", async () => {
@@ -157,24 +117,6 @@ describe("publish", () => {
     // When
     await processorAdapter.process(documents)();
     // Then
-    expect(mockGetPdvId).toHaveBeenCalledTimes(2);
-    expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
-    expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(1);
-    pipe(
-      [documents[0]],
-      RA.mapWithIndex((i, document) =>
-        expect(mockSendMessageViaQueue).toHaveBeenNthCalledWith(
-          i + 1,
-          Buffer.from(
-            JSON.stringify({
-              ...document
-              // DO NOT store pdvId values
-              // userPDVId: sha256(document.fiscalCode)
-            })
-          ).toString("base64")
-        )
-      )
-    );
-    expect(mockTrackException).toHaveBeenCalledTimes(0);
+    getEnricherFailureExpecter(documents);
   });
 });

--- a/businesslogic/__tests__/analytics-profiles.test.ts
+++ b/businesslogic/__tests__/analytics-profiles.test.ts
@@ -67,7 +67,7 @@ const aRetrievedProfileList = [
   {
     ...aRetrievedProfile,
     id: `${aFiscalCode}-0000000000000003` as NonEmptyString,
-    settingsVersion: 3 as NonNegativeInteger,
+    version: 3 as NonNegativeInteger,
     _ts: 1637077231001
   }
 ];

--- a/businesslogic/__tests__/analytics-profiles.test.ts
+++ b/businesslogic/__tests__/analytics-profiles.test.ts
@@ -1,0 +1,228 @@
+import { QueueClient } from "@azure/storage-queue";
+import { TelemetryClient } from "applicationinsights";
+import * as TE from "fp-ts/TaskEither";
+import {
+  INonNegativeIntegerTag,
+  NonNegativeInteger
+} from "@pagopa/ts-commons/lib/numbers";
+import { EmailString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { Producer, ProducerRecord } from "kafkajs";
+
+import { pipe } from "fp-ts/lib/function";
+import * as RA from "fp-ts/ReadonlyArray";
+
+import * as KA from "../../outbound/adapter/kafka-outbound-publisher";
+import * as QAF from "../../outbound/adapter/queue-outbound-mapper-publisher";
+import * as TA from "../../outbound/adapter/tracker-outbound-publisher";
+import * as PDVA from "../../outbound/adapter/pdv-id-outbound-enricher";
+
+import { getAnalyticsProcessorForDocuments } from "../analytics-publish-documents";
+
+import { aFiscalCode } from "../../__mocks__/services.mock";
+import { OutboundPublisher } from "../../outbound/port/outbound-publisher";
+import { sha256 } from "../../utils/pdv";
+import * as pdv from "../../utils/pdv";
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { ReminderStatusEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ReminderStatus";
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
+import { PushNotificationsContentTypeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PushNotificationsContentType";
+import { RetrievedProfileWithMaybePdvId } from "../../AnalyticsProfilesChangeFeedInboundProcessorAdapter";
+
+// Data
+
+const aTopic = "a-topic";
+const anError = new Error("An error");
+
+const aCosmosMetadata = {
+  _etag: "_etag",
+  _rid: "_rid",
+  _self: "xyz",
+  _ts: 1
+};
+
+const aRetrievedProfile: RetrievedProfile = {
+  ...aCosmosMetadata,
+  kind: "IRetrievedProfile",
+  id: `${aFiscalCode}-0000000000000002` as NonEmptyString,
+  fiscalCode: aFiscalCode,
+  isEmailEnabled: true,
+  isEmailValidated: true,
+  email: "an-email@email.com" as EmailString,
+  acceptedTosVersion: 22,
+  isInboxEnabled: true,
+  isWebhookEnabled: true,
+  preferredLanguages: [PreferredLanguageEnum.it_IT],
+  pushNotificationsContentType: PushNotificationsContentTypeEnum.FULL,
+  reminderStatus: ReminderStatusEnum.ENABLED,
+  servicePreferencesSettings: {
+    mode: ServicesPreferencesModeEnum.AUTO,
+    version: 1 as NonNegativeInteger
+  },
+  version: 2 as NonNegativeInteger,
+  isTestProfile: false,
+  lastAppVersion: "10.1.1" as RetrievedProfile["lastAppVersion"],
+  _ts: 1637077231000
+};
+const aRetrievedProfileList = [
+  aRetrievedProfile,
+  {
+    ...aRetrievedProfile,
+    id: `${aFiscalCode}-0000000000000003` as NonEmptyString,
+    settingsVersion: 3 as number & INonNegativeIntegerTag,
+    _ts: 1637077231001
+  }
+];
+
+// Mocks
+const mockTrackException = jest.fn(_ => void 0);
+const trackerMock = ({
+  trackException: mockTrackException
+} as unknown) as TelemetryClient;
+
+const mockSendMessageViaQueue = jest.fn(() => Promise.resolve());
+const mockQueueClient = ({
+  sendMessage: mockSendMessageViaQueue
+} as unknown) as QueueClient;
+
+const aKafkaResponse = {
+  errorCode: 0,
+  partition: 1,
+  topicName: aTopic
+};
+const mockSendMessageViaTopic = jest.fn(async (pr: ProducerRecord) =>
+  pipe(
+    pr.messages,
+    RA.map(() => aKafkaResponse)
+  )
+);
+const producerMock = () => ({
+  producer: ({
+    connect: jest.fn(async () => void 0),
+    disconnect: jest.fn(async () => void 0),
+    send: mockSendMessageViaTopic
+  } as unknown) as Producer,
+  topic: { topic: aTopic }
+});
+
+const mockGetPdvId = jest.spyOn(pdv, "getPdvId");
+
+const trackerAdapter = TA.create(trackerMock);
+
+const pdvIdEnricherAdapter = PDVA.create<RetrievedProfileWithMaybePdvId>(10);
+
+const mainAdapter = KA.create(producerMock) as OutboundPublisher<
+  RetrievedProfileWithMaybePdvId
+>;
+
+const fallbackAdapterWithFilter = QAF.create(profile => {
+  const { userPDVId, ...rest } = profile;
+  return rest;
+}, mockQueueClient) as OutboundPublisher<RetrievedProfileWithMaybePdvId>;
+
+// Tests
+
+describe("publish", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("GIVEN a valid list of profiles, WHEN processing the list, THEN publish it to the topic with enriched values", async () => {
+    // Given
+    const documents = aRetrievedProfileList;
+    const processorAdapter = getAnalyticsProcessorForDocuments(
+      RetrievedProfile,
+      trackerAdapter,
+      pdvIdEnricherAdapter,
+      mainAdapter,
+      fallbackAdapterWithFilter
+    );
+    // When
+    await processorAdapter.process(documents)();
+    // Then
+    expect(mockGetPdvId).toHaveBeenCalledTimes(2);
+    expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageViaTopic).toHaveBeenCalledWith({
+      messages: documents.map(document => ({
+        value: JSON.stringify({
+          ...document,
+          // enriched values
+          userPDVId: sha256(document.fiscalCode)
+        })
+      })),
+      topic: aTopic
+    });
+    expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(0);
+    expect(mockTrackException).toHaveBeenCalledTimes(0);
+  });
+
+  it("GIVEN a valid list of profile and a not working Kafka Producer Client, WHEN processing the list, THEN send it to the queue", async () => {
+    // Given
+    mockSendMessageViaTopic.mockImplementationOnce(async () => {
+      throw anError;
+    });
+    const documents = aRetrievedProfileList;
+    const processorAdapter = getAnalyticsProcessorForDocuments(
+      RetrievedProfile,
+      trackerAdapter,
+      pdvIdEnricherAdapter,
+      mainAdapter,
+      fallbackAdapterWithFilter
+    );
+    // When
+    await processorAdapter.process(documents)();
+    // Then
+    expect(mockGetPdvId).toHaveBeenCalledTimes(2);
+    expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(2);
+    pipe(
+      documents,
+      RA.mapWithIndex((i, document) =>
+        expect(mockSendMessageViaQueue).toHaveBeenNthCalledWith(
+          i + 1,
+          Buffer.from(
+            JSON.stringify({
+              ...document
+              // DO NOT store pdvId values
+              // userPDVId: sha256(document.fiscalCode)
+            })
+          ).toString("base64")
+        )
+      )
+    );
+    expect(mockTrackException).toHaveBeenCalledTimes(0);
+  });
+
+  it("GIVEN a valid list of profiles and a transient error on content enricher, WHEN processing the list, THEN send it to the queue", async () => {
+    // Given
+    mockGetPdvId.mockImplementationOnce(() => TE.left(Error("an Error")));
+    const documents = aRetrievedProfileList;
+    const processorAdapter = getAnalyticsProcessorForDocuments(
+      RetrievedProfile,
+      trackerAdapter,
+      pdvIdEnricherAdapter,
+      mainAdapter,
+      fallbackAdapterWithFilter
+    );
+    // When
+    await processorAdapter.process(documents)();
+    // Then
+    expect(mockGetPdvId).toHaveBeenCalledTimes(2);
+    expect(mockSendMessageViaTopic).toHaveBeenCalledTimes(1);
+    expect(mockSendMessageViaQueue).toHaveBeenCalledTimes(1);
+    pipe(
+      [documents[0]],
+      RA.mapWithIndex((i, document) =>
+        expect(mockSendMessageViaQueue).toHaveBeenNthCalledWith(
+          i + 1,
+          Buffer.from(
+            JSON.stringify({
+              ...document
+              // DO NOT store pdvId values
+              // userPDVId: sha256(document.fiscalCode)
+            })
+          ).toString("base64")
+        )
+      )
+    );
+    expect(mockTrackException).toHaveBeenCalledTimes(0);
+  });
+});

--- a/outbound/adapter/pdv-id-outbound-enricher.ts
+++ b/outbound/adapter/pdv-id-outbound-enricher.ts
@@ -7,9 +7,14 @@ import * as E from "fp-ts/Either";
 import { OutboundEnricher } from "../port/outbound-enricher";
 import { failure, success } from "../port/outbound-publisher";
 import { getPdvId } from "../../utils/pdv";
+import { RetrievedProfileWithMaybePdvId } from "../../AnalyticsProfilesChangeFeedInboundProcessorAdapter";
 import { RetrievedServicePreferenceWithMaybePdvId } from "../../utils/types/decoratedTypes";
 
-export const create = <M extends RetrievedServicePreferenceWithMaybePdvId>(
+type MaybePdvDocumentsTypes =
+  | RetrievedServicePreferenceWithMaybePdvId
+  | RetrievedProfileWithMaybePdvId;
+
+export const create = <M extends MaybePdvDocumentsTypes>(
   maxParallelThrottling: number
 ): OutboundEnricher<M> => {
   const enrichASingleMessage = (message: M): TE.TaskEither<Error, M> =>

--- a/outbound/adapter/pdv-id-outbound-enricher.ts
+++ b/outbound/adapter/pdv-id-outbound-enricher.ts
@@ -10,7 +10,7 @@ import { getPdvId } from "../../utils/pdv";
 import { RetrievedProfileWithMaybePdvId } from "../../AnalyticsProfilesChangeFeedInboundProcessorAdapter";
 import { RetrievedServicePreferenceWithMaybePdvId } from "../../utils/types/decoratedTypes";
 
-type MaybePdvDocumentsTypes =
+export type MaybePdvDocumentsTypes =
   | RetrievedServicePreferenceWithMaybePdvId
   | RetrievedProfileWithMaybePdvId;
 

--- a/utils/__tests__/profilesAvroFormatter.test.ts
+++ b/utils/__tests__/profilesAvroFormatter.test.ts
@@ -1,0 +1,105 @@
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import {
+  buildAvroProfileObject,
+  profilesAvroFormatter
+} from "../formatter/profilesAvroFormatter";
+import { aCosmosMetadata } from "../../businesslogic/__mocks__/processor.mock";
+import { aFiscalCode } from "../../__mocks__/services.mock";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
+import * as avro from "avsc";
+import { profile } from "../../generated/avro/dto/profile";
+import { RetrievedProfileWithMaybePdvId } from "../../AnalyticsProfilesChangeFeedInboundProcessorAdapter";
+import { sha256 } from "../pdv";
+import { PushNotificationsContentTypeEnum } from "../../generated/avro/dto/PushNotificationsContentTypeEnumEnum";
+import { ReminderStatusEnum } from "../../generated/avro/dto/ReminderStatusEnumEnum";
+const aUserPDVId = sha256(aFiscalCode);
+const aRetrievedProfile: RetrievedProfileWithMaybePdvId = {
+  ...aCosmosMetadata,
+  kind: "IRetrievedProfile",
+  id: `${aFiscalCode}-0000000000000002` as NonEmptyString,
+  fiscalCode: aFiscalCode,
+  servicePreferencesSettings: {
+    mode: ServicesPreferencesModeEnum.LEGACY,
+    version: -1
+  },
+  version: 1 as NonNegativeInteger,
+  _ts: 1637077231000,
+  userPDVId: aUserPDVId
+};
+describe("profileAvroFromatter", () => {
+  it("should serialize a valid profile with defaults", async () => {
+    const formatter = profilesAvroFormatter();
+
+    const avroFormattedValue = formatter(aRetrievedProfile);
+    const dtoExpected = buildAvroProfileObject(aRetrievedProfile);
+
+    const serviceSchema = avro.Type.forSchema(profile.schema as avro.Schema);
+
+    const decodedValue = serviceSchema.fromBuffer(
+      avroFormattedValue.value as Buffer
+    );
+
+    expect(decodedValue).toEqual(dtoExpected);
+    expect(decodedValue).toEqual(
+      expect.objectContaining({
+        id: aRetrievedProfile.id.replace(
+          aRetrievedProfile.fiscalCode,
+          aUserPDVId
+        ),
+        userPDVId: aUserPDVId,
+        // eslint-disable-next-line no-underscore-dangle
+        timestamp: aRetrievedProfile._ts * 1000,
+        acceptedTosVersion: "UNSET",
+        isEmailEnabled: false,
+        isEmailValidated: false,
+        isInboxEnabled: false,
+        isWebhookEnabled: false,
+        lastAppVersion: "UNKNOWN",
+        preferredLanguages: [],
+        pushNotificationsContentType: PushNotificationsContentTypeEnum.UNSET,
+        reminderStatus: ReminderStatusEnum.UNSET
+      })
+    );
+  });
+
+  it.each`
+    booleanPropertyName
+    ${"isEmailEnabled"}
+    ${"isEmailValidated"}
+    ${"isInboxEnabled"}
+    ${"isWebhookEnabled"}
+  `(
+    "should serialize boolean properties correctly avoid property confusion on $booleanPropertyName",
+    ({ booleanPropertyName }) => {
+      const formatter = profilesAvroFormatter();
+
+      const avroFormattedValue = formatter({
+        ...aRetrievedProfile,
+        [booleanPropertyName]: true
+      });
+      const dtoExpected = buildAvroProfileObject({
+        ...aRetrievedProfile,
+        [booleanPropertyName]: true
+      });
+
+      const serviceSchema = avro.Type.forSchema(profile.schema as avro.Schema);
+
+      const decodedValue = serviceSchema.fromBuffer(
+        avroFormattedValue.value as Buffer
+      );
+
+      expect(decodedValue).toEqual(dtoExpected);
+      expect(decodedValue).toEqual(
+        expect.objectContaining({
+          isEmailEnabled: false,
+          isEmailValidated: false,
+          isInboxEnabled: false,
+          isWebhookEnabled: false,
+          [booleanPropertyName]: true
+        })
+      );
+    }
+  );
+});

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -207,12 +207,19 @@ type ServicePreferencesKafkaTopicConfig = t.TypeOf<
   typeof ServicePreferencesKafkaTopicConfig
 >;
 
+const ProfilesKafkaTopicConfig = t.type({
+  PROFILES_TOPIC_CONNECTION_STRING: NonEmptyString,
+  PROFILES_TOPIC_NAME: NonEmptyString
+});
+type ProfilesKafkaTopicConfig = t.TypeOf<typeof ProfilesKafkaTopicConfig>;
+
 export interface IParsableConfig {
   readonly targetKafka: KafkaProducerCompactConfig;
 
   readonly MessagesKafkaTopicConfig: MessagesKafkaTopicConfig;
   readonly messageStatusKafkaTopicConfig: MessageStatusKafkaTopicConfig;
   readonly servicePreferencesKafkaTopicConfig: ServicePreferencesKafkaTopicConfig;
+  readonly profilesKafkaTopicConfig: ProfilesKafkaTopicConfig;
 }
 
 export const parseConfig = (input: unknown): t.Validation<IParsableConfig> =>
@@ -229,6 +236,9 @@ export const parseConfig = (input: unknown): t.Validation<IParsableConfig> =>
     ),
     E.bind("servicePreferencesKafkaTopicConfig", () =>
       ServicePreferencesKafkaTopicConfig.decode(input)
+    ),
+    E.bind("profilesKafkaTopicConfig", () =>
+      ProfilesKafkaTopicConfig.decode(input)
     )
   );
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -160,6 +160,7 @@ export const IDecodableConfig = t.interface({
   MESSAGE_STATUS_FAILURE_QUEUE_NAME: NonEmptyString,
   MESSAGES_FAILURE_QUEUE_NAME: NonEmptyString,
   SERVICE_PREFERENCES_FAILURE_QUEUE_NAME: NonEmptyString,
+  PROFILES_FAILURE_QUEUE_NAME: NonEmptyString,
 
   ENRICH_MESSAGE_THROTTLING: withDefault(
     NonNegativeInteger,

--- a/utils/formatter/profilesAvroFormatter.ts
+++ b/utils/formatter/profilesAvroFormatter.ts
@@ -1,0 +1,58 @@
+/* eslint-disable sort-keys */
+import * as avro from "avsc";
+import { PreferredLanguageEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/PreferredLanguage";
+import { MessageFormatter } from "../kafka/KafkaTypes";
+import { profile } from "../../generated/avro/dto/profile";
+import { RetrievedProfileWithMaybePdvId } from "../../AnalyticsProfilesChangeFeedInboundProcessorAdapter";
+import { PushNotificationsContentTypeEnum } from "../../generated/avro/dto/PushNotificationsContentTypeEnumEnum";
+import { ReminderStatusEnum } from "../../generated/avro/dto/ReminderStatusEnumEnum";
+import { BlockedInboxOrChannelEnum } from "../../generated/avro/dto/BlockedInboxOrChannelEnumEnum";
+
+// remove me
+export const buildAvroProfileObject = (
+  retrievedProfilesWithPdvId: RetrievedProfileWithMaybePdvId
+): Omit<profile, "schema" | "subject"> => ({
+  id: retrievedProfilesWithPdvId.id.replace(
+    retrievedProfilesWithPdvId.fiscalCode,
+    retrievedProfilesWithPdvId.userPDVId ?? "UNDEFINED"
+  ),
+  userPDVId: retrievedProfilesWithPdvId.userPDVId ?? "UNDEFINED",
+  // eslint-disable-next-line no-underscore-dangle
+  timestamp: retrievedProfilesWithPdvId._ts * 1000,
+  acceptedTosVersion:
+    retrievedProfilesWithPdvId.acceptedTosVersion?.toString() ?? "UNDEFINED",
+  blockedInboxOrChannels:
+    (retrievedProfilesWithPdvId.blockedInboxOrChannels as {
+      // eslint-disable-next-line functional/prefer-readonly-type
+      [index: string]: BlockedInboxOrChannelEnum[];
+    }) ?? {},
+  isEmailEnabled: retrievedProfilesWithPdvId.isEmailEnabled ?? false,
+  isEmailValidated: retrievedProfilesWithPdvId.isEmailValidated ?? false,
+  isInboxEnabled: retrievedProfilesWithPdvId.isEmailEnabled ?? false,
+  isWebhookEnabled: retrievedProfilesWithPdvId.isWebhookEnabled ?? false,
+  lastAppVersion: retrievedProfilesWithPdvId.lastAppVersion ?? "UNSET",
+  preferredLanguages:
+    // eslint-disable-next-line functional/prefer-readonly-type
+    (retrievedProfilesWithPdvId.preferredLanguages as PreferredLanguageEnum[]) ??
+    [],
+  pushNotificationsContentType: (retrievedProfilesWithPdvId.pushNotificationsContentType ??
+    PushNotificationsContentTypeEnum.UNSET) as PushNotificationsContentTypeEnum,
+  reminderStatus: (retrievedProfilesWithPdvId.reminderStatus ??
+    ReminderStatusEnum.UNSET) as ReminderStatusEnum,
+  servicePreferencesSettings:
+    retrievedProfilesWithPdvId.servicePreferencesSettings,
+  version: retrievedProfilesWithPdvId.version
+});
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const profilesAvroFormatter = (): MessageFormatter<RetrievedProfileWithMaybePdvId> => profileWithPdvId => {
+  const avroObject = buildAvroProfileObject(profileWithPdvId);
+
+  return {
+    // pdvId as Partition Key
+    key: avroObject.userPDVId,
+    value: avro.Type.forSchema(
+      profile.schema as avro.Schema // cast due to tsc can not proper recognize object as avro.Schema (eg. if you use const schemaServices: avro.Type = JSON.parse(JSON.stringify(services.schema())); it will loose the object type and it will work fine)
+    ).toBuffer(Object.assign(new profile(), avroObject))
+  };
+};

--- a/utils/formatter/profilesAvroFormatter.ts
+++ b/utils/formatter/profilesAvroFormatter.ts
@@ -28,7 +28,7 @@ export const buildAvroProfileObject = (
     }) ?? {},
   isEmailEnabled: retrievedProfilesWithPdvId.isEmailEnabled ?? false,
   isEmailValidated: retrievedProfilesWithPdvId.isEmailValidated ?? false,
-  isInboxEnabled: retrievedProfilesWithPdvId.isEmailEnabled ?? false,
+  isInboxEnabled: retrievedProfilesWithPdvId.isInboxEnabled ?? false,
   isWebhookEnabled: retrievedProfilesWithPdvId.isWebhookEnabled ?? false,
   lastAppVersion: retrievedProfilesWithPdvId.lastAppVersion ?? "UNKNOWN",
   preferredLanguages:

--- a/utils/formatter/profilesAvroFormatter.ts
+++ b/utils/formatter/profilesAvroFormatter.ts
@@ -20,7 +20,7 @@ export const buildAvroProfileObject = (
   // eslint-disable-next-line no-underscore-dangle
   timestamp: retrievedProfilesWithPdvId._ts * 1000,
   acceptedTosVersion:
-    retrievedProfilesWithPdvId.acceptedTosVersion?.toString() ?? "UNDEFINED",
+    retrievedProfilesWithPdvId.acceptedTosVersion?.toString() ?? "UNSET",
   blockedInboxOrChannels:
     (retrievedProfilesWithPdvId.blockedInboxOrChannels as {
       // eslint-disable-next-line functional/prefer-readonly-type
@@ -30,7 +30,7 @@ export const buildAvroProfileObject = (
   isEmailValidated: retrievedProfilesWithPdvId.isEmailValidated ?? false,
   isInboxEnabled: retrievedProfilesWithPdvId.isEmailEnabled ?? false,
   isWebhookEnabled: retrievedProfilesWithPdvId.isWebhookEnabled ?? false,
-  lastAppVersion: retrievedProfilesWithPdvId.lastAppVersion ?? "UNSET",
+  lastAppVersion: retrievedProfilesWithPdvId.lastAppVersion ?? "UNKNOWN",
   preferredLanguages:
     // eslint-disable-next-line functional/prefer-readonly-type
     (retrievedProfilesWithPdvId.preferredLanguages as PreferredLanguageEnum[]) ??


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add new change feed cosmos db trigger on the profile container.
Add new configuration env to bind the kafka queue for outbound documents.
PDV enrich utils support multiple document type

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To export profiles data to PDND we add a new processor for profiles documents

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
