### PR TITLE
[#IOPID-1926] Service Preferences failures queue processor

### DIFF
--- a/AnalyticsServicePreferencesChangeFeedInboundProcessorAdapter/index.ts
+++ b/AnalyticsServicePreferencesChangeFeedInboundProcessorAdapter/index.ts
@@ -1,10 +1,8 @@
 import { QueueClient } from "@azure/storage-queue";
 import { Context } from "@azure/functions";
 
-import * as t from "io-ts";
-
 import { RetrievedServicePreference } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
-import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 
 import * as KA from "../outbound/adapter/kafka-outbound-publisher";
 import * as KP from "../utils/kafka/KafkaProducerCompact";
@@ -21,14 +19,7 @@ import { servicePreferencesAvroFormatter } from "../utils/formatter/servicePrefe
 import { OutboundPublisher } from "../outbound/port/outbound-publisher";
 import { OutboundEnricher } from "../outbound/port/outbound-enricher";
 import { OutboundFilterer } from "../outbound/port/outbound-filterer";
-
-export type RetrievedServicePreferenceWithMaybePdvId = t.TypeOf<
-  typeof RetrievedServicePreferenceWithMaybePdvId
->;
-const RetrievedServicePreferenceWithMaybePdvId = t.intersection([
-  RetrievedServicePreference,
-  t.partial({ userPDVId: NonEmptyString })
-]);
+import { RetrievedServicePreferenceWithMaybePdvId } from "../utils/types/decoratedTypes";
 
 const config = getConfigOrThrow();
 

--- a/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/function.json
+++ b/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "servicePreferencesFailure",
+      "queueName": "%SERVICE_PREFERENCES_FAILURE_QUEUE_NAME%",
+      "connection":"INTERNAL_STORAGE_CONNECTION_STRING"
+    }
+  ],
+  "retry": {
+    "strategy": "exponentialBackoff",
+    "maxRetryCount": 5,
+    "minimumInterval": "00:00:05",
+    "maximumInterval": "00:30:00"
+  },
+  "scriptFile": "../dist/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/index.js"
+}

--- a/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/index.ts
+++ b/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/index.ts
@@ -1,0 +1,58 @@
+import { Context } from "@azure/functions";
+import { RetrievedServicePreference } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as t from "io-ts";
+import * as KP from "../utils/kafka/KafkaProducerCompact";
+import { ValidableKafkaProducerConfig } from "../utils/kafka/KafkaTypes";
+import { getConfigOrThrow } from "../utils/config";
+import * as KA from "../outbound/adapter/kafka-outbound-publisher";
+import * as EA from "../outbound/adapter/empty-outbound-publisher";
+import * as TA from "../outbound/adapter/tracker-outbound-publisher";
+import * as PDVA from "../outbound/adapter/pdv-id-outbound-enricher";
+import { OutboundPublisher } from "../outbound/port/outbound-publisher";
+import { getAnalyticsProcessorForDocuments } from "../businesslogic/analytics-publish-documents";
+import { OutboundEnricher } from "../outbound/port/outbound-enricher";
+import { servicePreferencesAvroFormatter } from "../utils/formatter/servicePreferencesAvroFormatter";
+
+export type RetrievedServicePreferenceWithMaybePdvId = t.TypeOf<
+  typeof RetrievedServicePreferenceWithMaybePdvId
+>;
+const RetrievedServicePreferenceWithMaybePdvId = t.intersection([
+  RetrievedServicePreference,
+  t.partial({ userPDVId: NonEmptyString })
+]);
+
+const config = getConfigOrThrow();
+
+const servicePreferencesTopic = {
+  ...config.targetKafka,
+  messageFormatter: servicePreferencesAvroFormatter()
+};
+
+const retrievedServicePreferencesOnKafkaAdapter: OutboundPublisher<RetrievedServicePreferenceWithMaybePdvId> = KA.create(
+  KP.fromConfig(
+    servicePreferencesTopic as ValidableKafkaProducerConfig, // cast due to wrong association between Promise<void> and t.Function ('brokers' field)
+    servicePreferencesTopic
+  )
+);
+
+const throwAdapter: OutboundPublisher<RetrievedServicePreferenceWithMaybePdvId> = EA.create();
+
+const telemetryAdapter = TA.create(
+  TA.initTelemetryClient(config.APPINSIGHTS_INSTRUMENTATIONKEY)
+);
+
+const pdvIdEnricherAdapter: OutboundEnricher<RetrievedServicePreferenceWithMaybePdvId> = PDVA.create<
+  RetrievedServicePreferenceWithMaybePdvId
+>(config.ENRICH_PDVID_THROTTLING);
+
+const run = (_context: Context, document: unknown): Promise<void> =>
+  getAnalyticsProcessorForDocuments(
+    RetrievedServicePreference,
+    telemetryAdapter,
+    pdvIdEnricherAdapter,
+    retrievedServicePreferencesOnKafkaAdapter,
+    throwAdapter
+  ).process([document])();
+
+export default run;

--- a/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/index.ts
+++ b/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/index.ts
@@ -4,7 +4,7 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as t from "io-ts";
 import * as KP from "../utils/kafka/KafkaProducerCompact";
 import { ValidableKafkaProducerConfig } from "../utils/kafka/KafkaTypes";
-import { getConfigOrThrow } from "../utils/config";
+import { getConfigOrThrow, withTopic } from "../utils/config";
 import * as KA from "../outbound/adapter/kafka-outbound-publisher";
 import * as EA from "../outbound/adapter/empty-outbound-publisher";
 import * as TA from "../outbound/adapter/tracker-outbound-publisher";
@@ -24,6 +24,12 @@ const RetrievedServicePreferenceWithMaybePdvId = t.intersection([
 
 const config = getConfigOrThrow();
 
+const servicePreferencesConfig = withTopic(
+  config.servicePreferencesKafkaTopicConfig.SERVICE_PREFERENCES_TOPIC_NAME,
+  config.servicePreferencesKafkaTopicConfig
+    .SERVICE_PREFERENCES_TOPIC_CONNECTION_STRING
+)(config.targetKafka);
+
 const servicePreferencesTopic = {
   ...config.targetKafka,
   messageFormatter: servicePreferencesAvroFormatter()
@@ -31,7 +37,7 @@ const servicePreferencesTopic = {
 
 const retrievedServicePreferencesOnKafkaAdapter: OutboundPublisher<RetrievedServicePreferenceWithMaybePdvId> = KA.create(
   KP.fromConfig(
-    servicePreferencesTopic as ValidableKafkaProducerConfig, // cast due to wrong association between Promise<void> and t.Function ('brokers' field)
+    servicePreferencesConfig as ValidableKafkaProducerConfig, // cast due to wrong association between Promise<void> and t.Function ('brokers' field)
     servicePreferencesTopic
   )
 );

--- a/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/index.ts
+++ b/AnalyticsServicePreferencesStorageQueueInboundProcessorAdapter/index.ts
@@ -1,7 +1,5 @@
 import { Context } from "@azure/functions";
 import { RetrievedServicePreference } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import * as t from "io-ts";
 import * as KP from "../utils/kafka/KafkaProducerCompact";
 import { ValidableKafkaProducerConfig } from "../utils/kafka/KafkaTypes";
 import { getConfigOrThrow, withTopic } from "../utils/config";
@@ -13,14 +11,7 @@ import { OutboundPublisher } from "../outbound/port/outbound-publisher";
 import { getAnalyticsProcessorForDocuments } from "../businesslogic/analytics-publish-documents";
 import { OutboundEnricher } from "../outbound/port/outbound-enricher";
 import { servicePreferencesAvroFormatter } from "../utils/formatter/servicePreferencesAvroFormatter";
-
-export type RetrievedServicePreferenceWithMaybePdvId = t.TypeOf<
-  typeof RetrievedServicePreferenceWithMaybePdvId
->;
-const RetrievedServicePreferenceWithMaybePdvId = t.intersection([
-  RetrievedServicePreference,
-  t.partial({ userPDVId: NonEmptyString })
-]);
+import { RetrievedServicePreferenceWithMaybePdvId } from "../utils/types/decoratedTypes";
 
 const config = getConfigOrThrow();
 
@@ -31,7 +22,7 @@ const servicePreferencesConfig = withTopic(
 )(config.targetKafka);
 
 const servicePreferencesTopic = {
-  ...config.targetKafka,
+  ...servicePreferencesConfig,
   messageFormatter: servicePreferencesAvroFormatter()
 };
 

--- a/businesslogic/__tests__/analytics-service-preferences.test.ts
+++ b/businesslogic/__tests__/analytics-service-preferences.test.ts
@@ -17,13 +17,13 @@ import * as QAF from "../../outbound/adapter/queue-outbound-mapper-publisher";
 import * as TA from "../../outbound/adapter/tracker-outbound-publisher";
 import * as PDVA from "../../outbound/adapter/pdv-id-outbound-enricher";
 
-import { RetrievedServicePreferenceWithMaybePdvId } from "../../AnalyticsServicePreferencesChangeFeedInboundProcessorAdapter";
 import { getAnalyticsProcessorForDocuments } from "../analytics-publish-documents";
 
 import { aFiscalCode } from "../../__mocks__/services.mock";
 import { OutboundPublisher } from "../../outbound/port/outbound-publisher";
 import { sha256 } from "../../utils/pdv";
 import * as pdv from "../../utils/pdv";
+import { RetrievedServicePreferenceWithMaybePdvId } from "../../utils/types/decoratedTypes";
 
 // Data
 

--- a/outbound/adapter/pdv-id-outbound-enricher.ts
+++ b/outbound/adapter/pdv-id-outbound-enricher.ts
@@ -7,7 +7,7 @@ import * as E from "fp-ts/Either";
 import { OutboundEnricher } from "../port/outbound-enricher";
 import { failure, success } from "../port/outbound-publisher";
 import { getPdvId } from "../../utils/pdv";
-import { RetrievedServicePreferenceWithMaybePdvId } from "../../AnalyticsServicePreferencesChangeFeedInboundProcessorAdapter";
+import { RetrievedServicePreferenceWithMaybePdvId } from "../../utils/types/decoratedTypes";
 
 export const create = <M extends RetrievedServicePreferenceWithMaybePdvId>(
   maxParallelThrottling: number

--- a/utils/formatter/servicePreferencesAvroFormatter.ts
+++ b/utils/formatter/servicePreferencesAvroFormatter.ts
@@ -2,7 +2,7 @@
 import * as avro from "avsc";
 import { MessageFormatter } from "../kafka/KafkaTypes";
 import { servicePreferences } from "../../generated/avro/dto/servicePreferences";
-import { RetrievedServicePreferenceWithMaybePdvId } from "../../AnalyticsServicePreferencesChangeFeedInboundProcessorAdapter";
+import { RetrievedServicePreferenceWithMaybePdvId } from "../types/decoratedTypes";
 
 // remove me
 export const buildAvroServicePreferencesObject = (

--- a/utils/types/decoratedTypes.ts
+++ b/utils/types/decoratedTypes.ts
@@ -1,0 +1,11 @@
+import { RetrievedServicePreference } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as t from "io-ts";
+
+export type RetrievedServicePreferenceWithMaybePdvId = t.TypeOf<
+  typeof RetrievedServicePreferenceWithMaybePdvId
+>;
+const RetrievedServicePreferenceWithMaybePdvId = t.intersection([
+  RetrievedServicePreference,
+  t.partial({ userPDVId: NonEmptyString })
+]);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add a new queue trigger to handle service preferences failures
<!--- Describe your changes in detail -->

#### Motivation and Context
When the change feed processor for Service Preference has an error a message is sent into the failure queue. The new trigger elaborate the message retrying all the outbound flow.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not yet

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
