### PR TITLE
[#IOPID-1924] Profile failures queue processor

### DIFF
--- a/AnalyticsProfileStorageQueueInboundProcessorAdapter/function.json
+++ b/AnalyticsProfileStorageQueueInboundProcessorAdapter/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "profilesFailure",
+      "queueName": "%PROFILES_FAILURE_QUEUE_NAME%",
+      "connection":"INTERNAL_STORAGE_CONNECTION_STRING"
+    }
+  ],
+  "retry": {
+    "strategy": "exponentialBackoff",
+    "maxRetryCount": 5,
+    "minimumInterval": "00:00:05",
+    "maximumInterval": "00:30:00"
+  },
+  "scriptFile": "../dist/AnalyticsProfileStorageQueueInboundProcessorAdapter/index.js"
+}

--- a/AnalyticsProfileStorageQueueInboundProcessorAdapter/index.ts
+++ b/AnalyticsProfileStorageQueueInboundProcessorAdapter/index.ts
@@ -30,7 +30,7 @@ const profilesConfig = withTopic(
 )(config.targetKafka);
 
 const profilesTopic = {
-  ...config.targetKafka,
+  ...profilesConfig,
   messageFormatter: profilesAvroFormatter()
 };
 

--- a/AnalyticsProfileStorageQueueInboundProcessorAdapter/index.ts
+++ b/AnalyticsProfileStorageQueueInboundProcessorAdapter/index.ts
@@ -1,0 +1,63 @@
+import { Context } from "@azure/functions";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as t from "io-ts";
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import * as KP from "../utils/kafka/KafkaProducerCompact";
+import { ValidableKafkaProducerConfig } from "../utils/kafka/KafkaTypes";
+import { getConfigOrThrow, withTopic } from "../utils/config";
+import * as KA from "../outbound/adapter/kafka-outbound-publisher";
+import * as EA from "../outbound/adapter/empty-outbound-publisher";
+import * as TA from "../outbound/adapter/tracker-outbound-publisher";
+import * as PDVA from "../outbound/adapter/pdv-id-outbound-enricher";
+import { OutboundPublisher } from "../outbound/port/outbound-publisher";
+import { getAnalyticsProcessorForDocuments } from "../businesslogic/analytics-publish-documents";
+import { OutboundEnricher } from "../outbound/port/outbound-enricher";
+import { profilesAvroFormatter } from "../utils/formatter/profilesAvroFormatter";
+
+export type RetrievedProfileWithMaybePdvId = t.TypeOf<
+  typeof RetrievedProfileWithMaybePdvId
+>;
+const RetrievedProfileWithMaybePdvId = t.intersection([
+  RetrievedProfile,
+  t.partial({ userPDVId: NonEmptyString })
+]);
+
+const config = getConfigOrThrow();
+
+const profilesConfig = withTopic(
+  config.profilesKafkaTopicConfig.PROFILES_TOPIC_NAME,
+  config.profilesKafkaTopicConfig.PROFILES_TOPIC_CONNECTION_STRING
+)(config.targetKafka);
+
+const profilesTopic = {
+  ...config.targetKafka,
+  messageFormatter: profilesAvroFormatter()
+};
+
+const retrievedServicePreferencesOnKafkaAdapter: OutboundPublisher<RetrievedProfileWithMaybePdvId> = KA.create(
+  KP.fromConfig(
+    profilesConfig as ValidableKafkaProducerConfig, // cast due to wrong association between Promise<void> and t.Function ('brokers' field)
+    profilesTopic
+  )
+);
+
+const throwAdapter: OutboundPublisher<RetrievedProfileWithMaybePdvId> = EA.create();
+
+const telemetryAdapter = TA.create(
+  TA.initTelemetryClient(config.APPINSIGHTS_INSTRUMENTATIONKEY)
+);
+
+const pdvIdEnricherAdapter: OutboundEnricher<RetrievedProfileWithMaybePdvId> = PDVA.create<
+  RetrievedProfileWithMaybePdvId
+>(config.ENRICH_PDVID_THROTTLING);
+
+const run = (_context: Context, document: unknown): Promise<void> =>
+  getAnalyticsProcessorForDocuments(
+    RetrievedProfile,
+    telemetryAdapter,
+    pdvIdEnricherAdapter,
+    retrievedServicePreferencesOnKafkaAdapter,
+    throwAdapter
+  ).process([document])();
+
+export default run;

--- a/AnalyticsProfileStorageQueueInboundProcessorAdapter/index.ts
+++ b/AnalyticsProfileStorageQueueInboundProcessorAdapter/index.ts
@@ -34,7 +34,7 @@ const profilesTopic = {
   messageFormatter: profilesAvroFormatter()
 };
 
-const retrievedServicePreferencesOnKafkaAdapter: OutboundPublisher<RetrievedProfileWithMaybePdvId> = KA.create(
+const retrievedProfilesOnKafkaAdapter: OutboundPublisher<RetrievedProfileWithMaybePdvId> = KA.create(
   KP.fromConfig(
     profilesConfig as ValidableKafkaProducerConfig, // cast due to wrong association between Promise<void> and t.Function ('brokers' field)
     profilesTopic
@@ -56,7 +56,7 @@ const run = (_context: Context, document: unknown): Promise<void> =>
     RetrievedProfile,
     telemetryAdapter,
     pdvIdEnricherAdapter,
-    retrievedServicePreferencesOnKafkaAdapter,
+    retrievedProfilesOnKafkaAdapter,
     throwAdapter
   ).process([document])();
 

--- a/local.settings.json.example
+++ b/local.settings.json.example
@@ -27,6 +27,11 @@
     "SERVICE_PREFERENCES_TOPIC_CONNECTION_STRING":"<Conn String>",
     "SERVICE_PREFERENCES_LEASES_PREFIX": "service-preferences-001",
     "SERVICE_PREFERENCES_FAILURE_QUEUE_NAME": "<Queue Name>-service-preferences",
+    
+    "PROFILES_TOPIC_NAME" : "pdnd-io-cosmosdb-profiles",
+    "PROFILES_TOPIC_CONNECTION_STRING" : "<Conn String>",
+    "PROFILES_LEASES_PREFIX" : "profiles-001",
+    "PROFILES_FAILURE_QUEUE_NAME" : "<Queue Name>-profiles",
 
     "SERVICEID_EXCLUSION_LIST": "ServiceId1,ServiceId2"
   }


### PR DESCRIPTION
⚠️ Depends on https://github.com/pagopa/io-functions-elt/pull/84
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add a new queue trigger from the profile failure queue to process document that has failure on change feed processor adapter.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When the export stage to kafka queue fail the document is sent to a failure queue. This trigger process that messages as retry mechanism.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
not yet

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
