### PR TITLE
[#IOPID-2352] Failure retry for Profile deletions

### DIFF
--- a/AnalyticsUserDataProcessingStorageQueueInboundProcessorAdapter/function.json
+++ b/AnalyticsUserDataProcessingStorageQueueInboundProcessorAdapter/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "deletionsFailure",
+      "queueName": "%DELETES_FAILURE_QUEUE_NAME%",
+      "connection":"INTERNAL_STORAGE_CONNECTION_STRING"
+    }
+  ],
+  "retry": {
+    "strategy": "exponentialBackoff",
+    "maxRetryCount": 5,
+    "minimumInterval": "00:00:05",
+    "maximumInterval": "00:30:00"
+  },
+  "scriptFile": "../dist/AnalyticsUserDataProcessingStorageQueueInboundProcessorAdapter/index.js"
+}

--- a/AnalyticsUserDataProcessingStorageQueueInboundProcessorAdapter/index.ts
+++ b/AnalyticsUserDataProcessingStorageQueueInboundProcessorAdapter/index.ts
@@ -1,0 +1,75 @@
+import { Context } from "@azure/functions";
+import { Second } from "@pagopa/ts-commons/lib/units";
+import { RetrievedUserDataProcessing } from "@pagopa/io-functions-commons/dist/src/models/user_data_processing";
+import * as KP from "../utils/kafka/KafkaProducerCompact";
+import { ValidableKafkaProducerConfig } from "../utils/kafka/KafkaTypes";
+import { getConfigOrThrow, withTopic } from "../utils/config";
+import * as KA from "../outbound/adapter/kafka-outbound-publisher";
+import * as EA from "../outbound/adapter/empty-outbound-publisher";
+import * as TA from "../outbound/adapter/tracker-outbound-publisher";
+import * as PDVA from "../outbound/adapter/pdv-id-outbound-enricher";
+import { OutboundPublisher } from "../outbound/port/outbound-publisher";
+import { getAnalyticsProcessorForDocuments } from "../businesslogic/analytics-publish-documents";
+import { OutboundEnricher } from "../outbound/port/outbound-enricher";
+import { pdvTokenizerClient } from "../utils/pdvTokenizerClient";
+import { httpOrHttpsApiFetch } from "../utils/fetch";
+import { createRedisClientSingleton } from "../utils/redis";
+import { profileDeletionAvroFormatter } from "../utils/formatter/deletesAvroFormatter";
+import { RetrievedUserDataProcessingWithMaybePdvId } from "../utils/types/decoratedTypes";
+
+const config = getConfigOrThrow();
+
+const profileDeletionConfig = withTopic(
+  config.deletesKafkaTopicConfig.DELETES_TOPIC_NAME,
+  config.deletesKafkaTopicConfig.DELETES_TOPIC_CONNECTION_STRING
+)(config.targetKafkaAuth);
+
+const profileDeletionTopic = {
+  ...profileDeletionConfig,
+  messageFormatter: profileDeletionAvroFormatter()
+};
+
+const profileDeletionsOnKafkaAdapter: OutboundPublisher<RetrievedUserDataProcessingWithMaybePdvId> = KA.create(
+  KP.fromConfig(
+    profileDeletionConfig as ValidableKafkaProducerConfig, // cast due to wrong association between Promise<void> and t.Function ('brokers' field)
+    profileDeletionTopic
+  )
+);
+
+const throwAdapter: OutboundPublisher<RetrievedUserDataProcessingWithMaybePdvId> = EA.create();
+
+const pdvTokenizer = pdvTokenizerClient(
+  config.PDV_TOKENIZER_BASE_URL,
+  config.PDV_TOKENIZER_API_KEY,
+  httpOrHttpsApiFetch,
+  config.PDV_TOKENIZER_BASE_PATH
+);
+
+const redisClientTask = createRedisClientSingleton(config);
+
+const telemetryClient = TA.initTelemetryClient(
+  config.APPINSIGHTS_INSTRUMENTATIONKEY
+);
+
+const telemetryAdapter = TA.create(telemetryClient);
+
+const pdvIdEnricherAdapter: OutboundEnricher<RetrievedUserDataProcessingWithMaybePdvId> = PDVA.create<
+  RetrievedUserDataProcessingWithMaybePdvId
+>(
+  config.ENRICH_PDVID_THROTTLING,
+  pdvTokenizer,
+  redisClientTask,
+  config.PDV_IDS_TTL as Second,
+  telemetryClient
+);
+
+const run = (_context: Context, document: unknown): Promise<void> =>
+  getAnalyticsProcessorForDocuments(
+    RetrievedUserDataProcessing,
+    telemetryAdapter,
+    pdvIdEnricherAdapter,
+    profileDeletionsOnKafkaAdapter,
+    throwAdapter
+  ).process([document])();
+
+export default run;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
New queue trigger to deletes failure queue that enable retry on failure
<!--- Describe your changes in detail -->

#### Motivation and Context
When some document in the CosmosDB trigger for Profile Deletions events fail, a document is inserted inside the retry queue. The trigger introduced in this PR listen this queue to performs retry. `5` more failure will put the document inside the poison queue.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Not yet
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
